### PR TITLE
Set getValueDependencies symbol to stream/compute results

### DIFF
--- a/can-stream-kefir_test.js
+++ b/can-stream-kefir_test.js
@@ -1,6 +1,7 @@
 var QUnit = require('steal-qunit');
 var canStream = require('can-stream-kefir');
 var compute = require('can-compute');
+var canReflect = require('can-reflect');
 var DefineList = require('can-define/list/list');
 
 QUnit.module('can-stream-kefir');
@@ -193,4 +194,32 @@ test('Computes with an initial value of undefined do not emit', function() {
 
 	expectedLength = 2;
 	people.pop();
+});
+
+QUnit.test('getValueDependencies - stream from compute', function(assert) {
+	var c = compute(0);
+	var stream = canStream.toStream(c);
+
+	assert.deepEqual(canReflect.getValueDependencies(stream), {
+		valueDependencies: new Set([c])
+	});
+});
+
+QUnit.test('getValueDependencies - streamedCompute', function(assert) {
+	var mergeStream;
+	var c = compute("a");
+	var letterStream = canStream.toStream(c);
+
+	var makeStream = function makeStream(setStream){
+		return (mergeStream = setStream.merge(letterStream));
+	};
+
+	var streamedCompute = canStream.toCompute(makeStream);
+
+	assert.deepEqual(
+		canReflect.getKeyDependencies(streamedCompute.computeInstance, "change"),
+		{
+			valueDependencies: new Set([ mergeStream ])
+		}
+	);
 });

--- a/package.json
+++ b/package.json
@@ -37,14 +37,16 @@
   "dependencies": {
     "can-compute": "^4.0.0-pre.6",
     "can-event": "^3.7.6",
+    "can-kefir": "^1.0.0-pre.1",
     "can-namespace": "^1.0.0",
     "can-observation": "^4.0.0-pre.24",
     "can-stream": "^1.0.0-pre.0",
-    "can-util": "^3.9.0",
-    "kefir": "^3.8.0"
+    "can-symbol": "^1.5.0",
+    "can-util": "^3.9.0"
   },
   "devDependencies": {
     "can-define": "^2.0.0-pre.21",
+    "can-reflect": "^1.11.1",
     "detect-cyclic-packages": "^1.1.0",
     "done-serve": "^1.3.0",
     "donejs-cli": "^1.0.1",


### PR DESCRIPTION
```js
var Person = DefineMap.extend({
  first: "string",
  last: "string",
  fullName: {
    get: function() {
      return this.first + " " + this.last;
    }
  },
  fullNameChangeCount: {
    stream: function() {
      return this.toStream(".fullName").scan(function(last) {
        return last + 1;
      }, 0);
    }
  }
});

canDefineStreamKefir(Person);

var me = new Person({ name: "John", last: "Doe" });
draw(
	document.querySelector("#container"),
	getGraph(me, "fullNameChangeCount")
);
```

Generates the following dependency graph:

![screen shot 2017-12-27 at 3 13 35 pm](https://user-images.githubusercontent.com/724877/34395153-58886b50-eb1b-11e7-8f58-e42547575836.png)

Note how from the the `fullNameChangeCount` it can see deps all the way to `DefineMap.first` and `DefineMap.last`. 